### PR TITLE
chore: upgrade Makefile and README to match template standards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,13 +110,13 @@ init: ## Bootstrap .env from .env.example (skip if .env already exists)
 
 lint: ## Lint code with ruff (no auto-fix) — entire repo
 	@printf "$(YELLOW)>>> Running ruff check...$(RESET)\n"
-	uv run --group lint ruff check .
+	uv run --group dev ruff check .
 	@printf "$(GREEN)>>> Lint passed!$(RESET)\n"
 
 format: ## Format code with ruff (format + auto-fix) — entire repo
 	@printf "$(YELLOW)>>> Running ruff format + fix...$(RESET)\n"
-	uv run --group lint ruff format .
-	uv run --group lint ruff check --fix .
+	uv run --group dev ruff format .
+	uv run --group dev ruff check --fix .
 	@printf "$(GREEN)>>> Format complete!$(RESET)\n"
 
 # ===========================================================================
@@ -125,12 +125,12 @@ format: ## Format code with ruff (format + auto-fix) — entire repo
 
 test: ## Run tests with pytest (no coverage)
 	@printf "$(YELLOW)>>> Running tests (no coverage)...$(RESET)\n"
-	uv run pytest -v -o addopts=
+	uv run pytest -v
 	@printf "$(GREEN)>>> Tests passed!$(RESET)\n"
 
 test-cov: ## Run tests with coverage report
 	@printf "$(YELLOW)>>> Running tests with coverage...$(RESET)\n"
-	uv run pytest -v
+	uv run pytest -v --cov=$(PKGROOT) --cov-report=term-missing --cov-report=xml
 	@printf "$(GREEN)>>> Coverage report generated!$(RESET)\n"
 
 # ===========================================================================

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ rbig/
 ├── rbig/                                 # Main package code (flat layout)
 ├── tests/                                # pytest test suite
 ├── docs/                                 # MkDocs documentation source
-├── notebooks/                            # Jupyter notebooks
+├── docs/notebooks/                       # Jupyter notebooks
 ├── .github/
 │   ├── workflows/                        # GitHub Actions CI/CD workflows
 │   ├── instructions/                     # Copilot custom instructions
@@ -141,7 +141,7 @@ All common tasks are available via `make`:
 
 | Workflow | File | Trigger | What it does |
 |----------|------|---------|-------------|
-| Tests | `ci.yml` | push / PR to main | pytest + Codecov upload |
+| Tests | `ci.yml` | push / PR to main | pytest (with coverage XML report) |
 | Lint | `lint.yml` | push / PR to main | `ruff check` + `ruff format --check` |
 | Deploy Docs | `docs.yml` | push to main | `mkdocs gh-deploy` |
 | Release Please | `release-please.yml` | push to main | automated release PR + changelog |


### PR DESCRIPTION
## Summary

- **Makefile** (#44): Rewritten to match pypackage_template format — adds `.env` support, calculated variables (`GIT_HASH`, `PKG_VERSION`), guard pattern, and new targets (`init`, `test-cov`, `build`, `clean`, `version`, `docs`, `docs-deploy`). Renames `uv-*` targets to clean names (`lint`, `format`, `test`, `precommit`) with backwards-compatible aliases. Ruff commands use `.` (entire repo) to match CI.
- **README** (#43): Expanded from minimal state to comprehensive format — full badge suite (10 badges), repository layout diagram, developer quick start with `make` targets table, CI/CD workflow summary (9 workflows), contributing section, and further reading links. All existing content (overview, features, install, quick start, citation, license) preserved.

Closes #43
Closes #44

## Test plan

- [x] `make help` — displays all targets with correct descriptions
- [x] `make version` — shows package version and git hash
- [x] `make init` — bootstraps `.env` from `.env.example`
- [ ] `make lint` — runs ruff on entire repo
- [ ] `make test` — runs pytest
- [ ] Verify old aliases (`make uv-lint`, `make uv-test`, etc.) still work
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)