### PR TITLE
fix(docs): render pre-executed ipynb notebooks with figures

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,8 @@ plugins:
   - mkdocs-jupyter:
       execute: false
       ignore_h1_titles: true
+      include: ["*.ipynb"]
+      ignore: ["*.py"]
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary
- mkdocs-jupyter was processing both `.py` and `.ipynb` files for each notebook, and the `.py` version (no outputs) overwrote the pre-executed `.ipynb` rendering
- Added `include: ["*.ipynb"]` and `ignore: ["*.py"]` to the mkdocs-jupyter plugin config so only the pre-executed notebooks are rendered
- This fixes the missing plot figures on the docs site

## Test plan
- [x] Verified locally: `mkdocs build` now only converts `.ipynb` files
- [x] Confirmed the built HTML contains 5 embedded PNG plot images for notebook 01 (previously 0)
- [x] Execution counts (`In [1]:`, etc.) now appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)