### PR TITLE
feat: add Sliced Iterative Gaussianization (SIG/GIS)

### DIFF
--- a/rbig/__init__.py
+++ b/rbig/__init__.py
@@ -101,6 +101,8 @@ from rbig._src.rotation import (
     RandomOrthogonalProjection,
     RandomRotation,
 )
+from rbig._src.sliced import GIS, SIG, SIGLayer
+from rbig._src.spline import RQSpline
 from rbig._src.xarray_image import matrix_to_xr_image, xr_apply_rbig, xr_image_to_matrix
 from rbig._src.xarray_st import (
     XarrayRBIG,
@@ -111,6 +113,8 @@ from rbig._src.xarray_st import (
 from rbig._version import __version__
 
 __all__ = [
+    "GIS",
+    "SIG",
     "AnnealedRBIG",
     "BaseITMeasure",
     "BaseTransform",
@@ -139,10 +143,12 @@ __all__ = [
     "QuantileGaussianizer",
     "QuantileTransform",
     "RBIGLayer",
+    "RQSpline",
     "RandomChannelRotation",
     "RandomOrthogonalProjection",
     "RandomRotation",
     "RotationBijector",
+    "SIGLayer",
     "SplineGaussianizer",
     "Tanh",
     "WaveletTransform",

--- a/rbig/_src/convergence.py
+++ b/rbig/_src/convergence.py
@@ -1,0 +1,205 @@
+"""Shared convergence / early-stopping criteria for iterative Gaussianization.
+
+Iterative Gaussianization models (``AnnealedRBIG``, ``GIS``, ``SIG``) stack
+layers greedily until the data is "Gaussian enough".  Different signals can
+drive that decision, trading principle against cost:
+
+* ``"log_likelihood"`` -- validation log-likelihood under the
+  change-of-variables formula.  Most principled; needs the accumulated
+  log-determinant each iteration.
+* ``"swd"`` -- K-sliced Wasserstein distance between the current
+  representation and a standard Gaussian.  Cheap proxy for the remaining
+  non-Gaussianity.
+* ``"total_correlation"`` -- residual total correlation of the current
+  representation (the classic RBIG signal).
+
+:class:`StoppingCriterion` tracks the chosen metric across iterations and
+signals when training should stop, applying a ``patience`` window so that a
+few non-improving layers do not halt training prematurely.
+
+References
+----------
+Laparra, V., Camps-Valls, G., & Malo, J. (2011). Iterative Gaussianization:
+from ICA to Random Rotations. *IEEE Transactions on Neural Networks*, 22(4),
+537-549.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy import stats
+
+from rbig._src.stiefel import wasserstein_1d
+
+_VALID_METRICS = ("log_likelihood", "swd", "total_correlation")
+# Whether a larger metric value indicates a better (more converged) model.
+_GREATER_IS_BETTER = {
+    "log_likelihood": True,
+    "swd": False,
+    "total_correlation": False,
+}
+
+
+class StoppingCriterion:
+    """Track a convergence metric and signal early stopping.
+
+    Parameters
+    ----------
+    metric : {"log_likelihood", "swd", "total_correlation"}, default "log_likelihood"
+        Which signal drives stopping.
+    patience : int, default 10
+        Number of consecutive non-improving updates tolerated before
+        :meth:`update` returns ``True``.
+    min_delta : float, default 1e-4
+        Minimum change in the metric counted as an improvement.
+    validation_fraction : float, default 0.2
+        Fraction of data held out by :meth:`split` for monitoring.  Set to
+        ``0`` to monitor on the training data itself.
+    n_projections : int, default 50
+        Number of random 1D projections used by the ``"swd"`` metric.
+    random_state : int or None, optional
+        Seed controlling the validation split and the ``"swd"`` reference
+        sample / projections.
+
+    Attributes
+    ----------
+    history_ : list of float
+        Metric value recorded at each :meth:`update`.
+    best_score_ : float or None
+        Best metric value seen so far (in the metric's natural orientation).
+    best_iter_ : int
+        Index of the update that achieved ``best_score_``.
+    """
+
+    def __init__(
+        self,
+        metric: str = "log_likelihood",
+        patience: int = 10,
+        min_delta: float = 1e-4,
+        validation_fraction: float = 0.2,
+        n_projections: int = 50,
+        random_state: int | None = None,
+    ):
+        if metric not in _VALID_METRICS:
+            raise ValueError(
+                f"Unknown metric {metric!r}. Choose from {_VALID_METRICS}."
+            )
+        self.metric = metric
+        self.patience = patience
+        self.min_delta = min_delta
+        self.validation_fraction = validation_fraction
+        self.n_projections = n_projections
+        self.random_state = random_state
+        self.reset()
+
+    def reset(self) -> None:
+        """Clear all tracked state so the criterion can be reused."""
+        self.history_: list[float] = []
+        self.best_score_: float | None = None
+        self.best_iter_: int = -1
+        self._n_bad_: int = 0
+        self._iter_: int = -1
+        self._rng_ = np.random.default_rng(self.random_state)
+
+    def split(
+        self, X: np.ndarray, random_state: int | None = None
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Split ``X`` into train / validation parts.
+
+        Parameters
+        ----------
+        X : np.ndarray of shape (n_samples, n_features)
+            Data to split.
+        random_state : int or None, optional
+            Overrides the criterion's ``random_state`` for this split.
+
+        Returns
+        -------
+        X_train, X_val : np.ndarray
+            The two partitions.  When ``validation_fraction == 0`` both are
+            the full array.
+        """
+        if self.validation_fraction <= 0:
+            return X, X
+        from sklearn.model_selection import train_test_split
+
+        seed = self.random_state if random_state is None else random_state
+        return train_test_split(
+            X, test_size=self.validation_fraction, random_state=seed
+        )
+
+    def _score(self, X_val: np.ndarray, log_det: np.ndarray | None) -> float:
+        """Compute the configured metric on the current representation."""
+        if self.metric == "log_likelihood":
+            log_pz = np.sum(stats.norm.logpdf(X_val), axis=1)
+            if log_det is None:
+                log_det = np.zeros(X_val.shape[0])
+            return float(np.mean(log_pz + log_det))
+
+        if self.metric == "swd":
+            d = X_val.shape[1]
+            ref = self._rng_.standard_normal(X_val.shape)
+            dirs = self._rng_.standard_normal((d, self.n_projections))
+            dirs /= np.linalg.norm(dirs, axis=0, keepdims=True)
+            proj_x = X_val @ dirs
+            proj_z = ref @ dirs
+            return float(
+                np.mean(
+                    [
+                        wasserstein_1d(proj_x[:, j], proj_z[:, j])
+                        for j in range(self.n_projections)
+                    ]
+                )
+            )
+
+        # total_correlation
+        from rbig._src.densities import joint_entropy_gaussian, marginal_entropy
+
+        marg = marginal_entropy(X_val)
+        joint = joint_entropy_gaussian(X_val)
+        return float(np.sum(marg) - joint)
+
+    def update(self, X_val: np.ndarray, log_det: np.ndarray | None = None) -> bool:
+        """Record the metric for the current iterate and test for stopping.
+
+        Parameters
+        ----------
+        X_val : np.ndarray of shape (n_samples, n_features)
+            The validation data **after** passing through all layers fitted
+            so far (i.e. the current latent representation).
+        log_det : np.ndarray of shape (n_samples,) or None, optional
+            Accumulated per-sample log-determinant on ``X_val``.  Required
+            only for the ``"log_likelihood"`` metric.
+
+        Returns
+        -------
+        should_stop : bool
+            ``True`` when the metric has failed to improve for ``patience``
+            consecutive updates.
+        """
+        self._iter_ += 1
+        score = self._score(X_val, log_det)
+        self.history_.append(score)
+
+        greater_is_better = _GREATER_IS_BETTER[self.metric]
+        if self.best_score_ is None:
+            improved = True
+        elif greater_is_better:
+            improved = score > self.best_score_ + self.min_delta
+        else:
+            improved = score < self.best_score_ - self.min_delta
+
+        if improved:
+            self.best_score_ = score
+            self.best_iter_ = self._iter_
+            self._n_bad_ = 0
+        else:
+            self._n_bad_ += 1
+
+        return self._n_bad_ >= self.patience
+
+    def best_score(self) -> float:
+        """Return the best metric value observed so far."""
+        if self.best_score_ is None:
+            raise ValueError("No updates recorded yet; call update() first.")
+        return self.best_score_

--- a/rbig/_src/marginal.py
+++ b/rbig/_src/marginal.py
@@ -31,6 +31,7 @@ from scipy import stats
 from scipy.special import ndtri
 
 from rbig._src.base import BaseTransform, Bijector
+from rbig._src.spline import RQSpline
 
 
 def make_cdf_monotonic(cdf: np.ndarray) -> np.ndarray:
@@ -1295,50 +1296,46 @@ class GMMGaussianizer(Bijector):
 
 
 class SplineGaussianizer(Bijector):
-    """Gaussianize each marginal using monotone PCHIP spline interpolation.
+    """Gaussianize each marginal using a monotonic rational-quadratic spline.
 
-    Estimates the marginal CDF from empirical quantiles and fits a
-    shape-preserving (monotone) cubic Hermite spline (PCHIP) from
-    original-space quantile values to the corresponding Gaussian quantiles.
-    The forward transform is::
+    Each feature is Gaussianized with an independent :class:`RQSpline` -- the
+    shared 1D rational-quadratic spline primitive that also backs the
+    SIG/GIS layers.  The forward transform is::
 
-        z = S(x)
+        z = g(x)
 
-    where ``S`` is the fitted :class:`scipy.interpolate.PchipInterpolator`
-    mapping data values to standard-normal quantiles.  Because PCHIP
-    preserves monotonicity, the mapping is guaranteed to be invertible.
+    where ``g`` composes a KDE-estimated CDF with the Gaussian quantile
+    function.  The spline is monotone by construction (positive knot
+    derivatives) and its inverse is analytic, so the mapping is exactly
+    invertible.
 
     Parameters
     ----------
     n_quantiles : int, default 200
-        Number of quantile nodes used to fit the splines.  Capped at
-        ``n_samples`` when fewer training samples are available.
+        Number of spline knots.  Capped at ``n_samples`` when fewer training
+        samples are available.  (Maps to :class:`RQSpline`'s ``n_knots``.)
     eps : float, default 1e-6
-        Clipping margin applied to the Gaussian quantile grid to keep
-        the spline endpoints finite (avoids +/-inf at boundary quantiles).
+        Clipping margin applied to CDF values before the probit, keeping the
+        target knots finite.
 
     Attributes
     ----------
-    splines_ : list of scipy.interpolate.PchipInterpolator
-        Forward splines (x -> z) per feature, mapping original-space
-        values to standard-normal quantiles.
-    inv_splines_ : list of scipy.interpolate.PchipInterpolator
-        Inverse splines (z -> x) per feature, mapping Gaussian quantiles
-        back to original-space values.
+    splines_ : list of RQSpline
+        One fitted rational-quadratic spline per feature, each mapping
+        original-space values to standard-normal values (and back).
     n_features_ : int
         Number of feature dimensions seen during ``fit``.
 
     Notes
     -----
-    The log-det-Jacobian uses the analytic first derivative of the spline::
+    The log-det-Jacobian uses the analytic spline derivative returned by the
+    forward pass::
 
-        log|dz/dx| = log|S'(x)|
+        log|dz/dx| = log|g'(x)|
 
-    where ``S'`` is the first derivative of the PCHIP forward spline,
-    evaluated via ``spline(x, 1)`` (the derivative-order argument).
-
-    Duplicate x-values (arising from discrete or constant features) are
-    removed before fitting to ensure strict monotonicity.
+    Between knots ``g`` is a rational-quadratic interpolant; outside the
+    outermost knots it extends linearly, so both the transform and its
+    inverse are finite and analytic everywhere.
 
     References
     ----------
@@ -1366,12 +1363,11 @@ class SplineGaussianizer(Bijector):
         self.eps = eps
 
     def fit(self, X: np.ndarray, y=None) -> SplineGaussianizer:
-        """Fit forward and inverse PCHIP splines for each feature.
+        """Fit one rational-quadratic spline per feature.
 
-        For each dimension, ``n_quantiles`` evenly-spaced probability levels
-        are mapped to their empirical quantile values in the data, and the
-        corresponding Gaussian quantile values ``Phi^{-1}(p)`` are computed.
-        PCHIP interpolants are then fitted in both directions.
+        For each dimension an :class:`RQSpline` is fitted with up to
+        ``n_quantiles`` knots, estimating the marginal CDF by KDE and placing
+        the target knots at the corresponding Gaussian quantiles.
 
         Parameters
         ----------
@@ -1383,27 +1379,13 @@ class SplineGaussianizer(Bijector):
         self : SplineGaussianizer
             Fitted bijector instance.
         """
-        from scipy.interpolate import PchipInterpolator
-
-        self.splines_ = []
-        self.inv_splines_ = []
         self.n_features_ = X.shape[1]
-        # Use at most n_samples quantile nodes
-        n_q = min(self.n_quantiles, X.shape[0])
-        # Probability grid: n_q evenly-spaced points in [0, 1]
-        quantiles = np.linspace(0, 1, n_q)
-        # Corresponding Gaussian quantiles Phi^{-1}(p), clipped away from +/-inf
-        g_q = ndtri(np.clip(quantiles, self.eps, 1 - self.eps))
-        for i in range(self.n_features_):
-            xi_sorted = np.sort(X[:, i])
-            # Empirical quantile values at each probability level
-            x_q = np.quantile(xi_sorted, quantiles)
-            # Remove duplicate x values so PchipInterpolator gets a strictly
-            # increasing sequence (duplicates arise with discrete/tied data).
-            x_q_u, idx = np.unique(x_q, return_index=True)
-            g_q_u = g_q[idx]
-            self.splines_.append(PchipInterpolator(x_q_u, g_q_u))
-            self.inv_splines_.append(PchipInterpolator(g_q_u, x_q_u))
+        # One shared RQ-spline primitive per feature dimension.  The same
+        # primitive backs the SIG/GIS layers (see rbig._src.spline).
+        self.splines_ = [
+            RQSpline(n_knots=self.n_quantiles, eps=self.eps).fit(X[:, i])
+            for i in range(self.n_features_)
+        ]
         return self
 
     def transform(self, X: np.ndarray) -> np.ndarray:
@@ -1421,8 +1403,8 @@ class SplineGaussianizer(Bijector):
         """
         Xt = np.zeros_like(X, dtype=float)
         for i in range(self.n_features_):
-            # Evaluate the forward PCHIP spline at the input values
-            Xt[:, i] = self.splines_[i](X[:, i])
+            # Forward RQ-spline Gaussianization for feature i
+            Xt[:, i], _ = self.splines_[i].forward(X[:, i])
         return Xt
 
     def inverse_transform(self, X: np.ndarray) -> np.ndarray:
@@ -1440,8 +1422,8 @@ class SplineGaussianizer(Bijector):
         """
         Xt = np.zeros_like(X, dtype=float)
         for i in range(self.n_features_):
-            # Evaluate the inverse PCHIP spline at the Gaussian values
-            Xt[:, i] = self.inv_splines_[i](X[:, i])
+            # Analytic inverse of the RQ spline for feature i
+            Xt[:, i], _ = self.splines_[i].inverse(X[:, i])
         return Xt
 
     def get_log_det_jacobian(self, X: np.ndarray) -> np.ndarray:
@@ -1466,6 +1448,7 @@ class SplineGaussianizer(Bijector):
         """
         log_det = np.zeros(X.shape[0])
         for i in range(self.n_features_):
-            deriv = self.splines_[i](X[:, i], 1)  # first derivative
-            log_det += np.log(np.maximum(np.abs(deriv), 1e-300))
+            # Analytic log|dz/dx| from the RQ spline forward pass
+            _, log_dz = self.splines_[i].forward(X[:, i])
+            log_det += log_dz
         return log_det

--- a/rbig/_src/sliced.py
+++ b/rbig/_src/sliced.py
@@ -1,0 +1,529 @@
+"""Sliced Iterative Gaussianization: SIGLayer, GIS, and SIG.
+
+This module implements the Sliced Iterative Gaussianization family of
+Dai & Seljak (2020).  The building block is :class:`SIGLayer`, which finds
+``K`` orthonormal projection directions (via Stiefel-manifold optimization
+or at random) and applies a 1D rational-quadratic spline Gaussianization
+along each of them, leaving the orthogonal complement untouched.
+
+Two scikit-learn estimators stack these layers greedily:
+
+* :class:`GIS` -- *Gaussianization via Iterative Slicing*.  Maps arbitrary
+  data to a standard Gaussian; oriented toward density estimation
+  (``transform`` / ``score_samples``).
+* :class:`SIG` -- *Sliced Iterative Gaussianization*.  The same underlying
+  flow oriented toward generation (``sample`` / ``inverse_transform``),
+  defaulting to a sliced-Wasserstein stopping signal.
+
+Both compose with a shared whitening pre-transform and the shared
+:class:`~rbig._src.convergence.StoppingCriterion`, and both define a valid
+normalizing flow with a tractable log-determinant.
+
+References
+----------
+Dai, B., & Seljak, U. (2020). Sliced Iterative Normalizing Flows.
+https://arxiv.org/abs/2007.00674
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy import stats
+from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.utils.validation import check_is_fitted, validate_data
+
+from rbig._src.convergence import StoppingCriterion
+from rbig._src.rotation import PCARotation
+from rbig._src.spline import RQSpline
+from rbig._src.stiefel import (
+    max_sliced_wasserstein_directions,
+    random_orthogonal_directions,
+)
+
+
+class SIGLayer:
+    """One sliced-Gaussianization layer: projection + per-direction splines.
+
+    The layer finds ``K`` orthonormal directions ``A`` and Gaussianizes the
+    source data along each via an independent :class:`RQSpline`.  The
+    component orthogonal to ``A`` is passed through unchanged, so in the
+    rotated basis the map is ``(g_1, ..., g_K, identity, ...)`` and its
+    log-determinant is the sum of the per-direction spline log-derivatives.
+
+    Parameters
+    ----------
+    n_directions : int, default 1
+        Number of projection directions ``K``.
+    n_knots : int, default 1000
+        Knots per 1D spline (see :class:`RQSpline`).
+    alpha : float, default 1e-3
+        Lower clip on spline derivatives (regularizes extreme slopes).
+    direction_method : {"stiefel", "random"}, default "stiefel"
+        How projection directions are found.  ``"stiefel"`` maximizes the
+        K-sliced Wasserstein distance between source and target; ``"random"``
+        draws a random orthonormal frame.
+    stiefel_lr : float, default 1.0
+        Initial step size for the Stiefel line search.
+    stiefel_max_iter : int, default 100
+        Maximum Stiefel optimization iterations.
+    kde_bandwidth : str, float, or None, default None
+        Bandwidth passed to each spline's KDE.
+    random_state : int or None, optional
+        Seed for direction finding and the Gaussian reference.
+
+    Attributes
+    ----------
+    A_ : np.ndarray of shape (n_features, n_directions)
+        Fitted orthonormal projection directions.
+    splines_ : list of RQSpline
+        One fitted spline per direction.
+    n_features_in_ : int
+        Number of input features seen during :meth:`fit`.
+    """
+
+    def __init__(
+        self,
+        n_directions: int = 1,
+        n_knots: int = 1000,
+        alpha: float = 1e-3,
+        direction_method: str = "stiefel",
+        stiefel_lr: float = 1.0,
+        stiefel_max_iter: int = 100,
+        kde_bandwidth: str | float | None = None,
+        random_state: int | None = None,
+    ):
+        self.n_directions = n_directions
+        self.n_knots = n_knots
+        self.alpha = alpha
+        self.direction_method = direction_method
+        self.stiefel_lr = stiefel_lr
+        self.stiefel_max_iter = stiefel_max_iter
+        self.kde_bandwidth = kde_bandwidth
+        self.random_state = random_state
+
+    def fit(self, X: np.ndarray, X_target: np.ndarray | None = None) -> SIGLayer:
+        """Find directions and fit a Gaussianizing spline along each.
+
+        Parameters
+        ----------
+        X : np.ndarray of shape (n_samples, n_features)
+            Source data to Gaussianize.  The splines are fitted on the
+            projections of ``X``.
+        X_target : np.ndarray or None, optional
+            Reference used only for direction finding with the ``"stiefel"``
+            method.  When ``None`` a standard-Gaussian sample matching ``X``
+            is drawn.
+
+        Returns
+        -------
+        self : SIGLayer
+            The fitted layer.
+        """
+        X = np.asarray(X, dtype=float)
+        n, d = X.shape
+        self.n_features_in_ = d
+        k = max(1, min(self.n_directions, d))
+        rng = np.random.default_rng(self.random_state)
+
+        if self.direction_method == "random":
+            self.A_ = random_orthogonal_directions(
+                d, k, random_state=int(rng.integers(2**31))
+            )
+        elif self.direction_method == "stiefel":
+            if X_target is None:
+                X_target = rng.standard_normal((n, d))
+            self.A_ = max_sliced_wasserstein_directions(
+                X,
+                X_target,
+                k,
+                max_iter=self.stiefel_max_iter,
+                lr=self.stiefel_lr,
+                random_state=int(rng.integers(2**31)),
+            )
+        else:
+            raise ValueError(
+                f"Unknown direction_method {self.direction_method!r}. "
+                "Use 'stiefel' or 'random'."
+            )
+
+        X_proj = X @ self.A_  # (n, k)
+        self.splines_ = [
+            RQSpline(
+                n_knots=self.n_knots,
+                kde_bw=self.kde_bandwidth,
+                min_derivative=self.alpha,
+            ).fit(X_proj[:, j])
+            for j in range(k)
+        ]
+        return self
+
+    def transform(self, X: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """Gaussianize along ``A`` and accumulate the log-determinant.
+
+        Parameters
+        ----------
+        X : np.ndarray of shape (n_samples, n_features)
+            Input data.
+
+        Returns
+        -------
+        X_new : np.ndarray of shape (n_samples, n_features)
+            Data with the ``K`` projected directions Gaussianized.
+        log_det : np.ndarray of shape (n_samples,)
+            Per-sample log absolute determinant of the layer.
+        """
+        X = np.asarray(X, dtype=float)
+        X_proj = X @ self.A_
+        residual = X - X_proj @ self.A_.T
+        z_proj = np.empty_like(X_proj)
+        log_det = np.zeros(X.shape[0])
+        for j, spline in enumerate(self.splines_):
+            z_proj[:, j], log_dz = spline.forward(X_proj[:, j])
+            log_det += log_dz
+        return residual + z_proj @ self.A_.T, log_det
+
+    def inverse_transform(self, Z: np.ndarray) -> np.ndarray:
+        """Invert the layer.
+
+        Parameters
+        ----------
+        Z : np.ndarray of shape (n_samples, n_features)
+            Data in the layer's output space.
+
+        Returns
+        -------
+        X : np.ndarray of shape (n_samples, n_features)
+            Recovered input-space data.
+        """
+        Z = np.asarray(Z, dtype=float)
+        Z_proj = Z @ self.A_
+        residual = Z - Z_proj @ self.A_.T
+        x_proj = np.empty_like(Z_proj)
+        for j, spline in enumerate(self.splines_):
+            x_proj[:, j], _ = spline.inverse(Z_proj[:, j])
+        return residual + x_proj @ self.A_.T
+
+
+class _BaseSliced(TransformerMixin, BaseEstimator):
+    """Shared machinery for the sliced-Gaussianization estimators.
+
+    Subclasses (:class:`GIS`, :class:`SIG`) supply the parameter set via
+    their own ``__init__`` and differ only in default configuration; the
+    fit/transform/score logic lives here.
+    """
+
+    def _resolve_directions(self, d: int) -> int:
+        """Resolve ``K`` per layer (default ``D // 2``, at least 1)."""
+        if self.n_directions is None:
+            return max(1, d // 2)
+        return max(1, min(self.n_directions, d))
+
+    def fit(self, X: np.ndarray, y=None) -> _BaseSliced:
+        """Greedily stack sliced-Gaussianization layers.
+
+        Whitens the data (optional), then repeatedly fits a
+        :class:`SIGLayer` on the running representation, advancing it toward
+        a standard Gaussian and monitoring a held-out
+        :class:`StoppingCriterion` for early stopping.
+
+        Parameters
+        ----------
+        X : np.ndarray of shape (n_samples, n_features)
+            Training data.
+        y : ignored
+            Present for scikit-learn compatibility.
+
+        Returns
+        -------
+        self : _BaseSliced
+            The fitted model.
+        """
+        X = validate_data(self, X)
+        n, d = X.shape
+        if n < 2:
+            raise ValueError(f"Need at least 2 samples, got {n}.")
+        self.n_features_in_ = d
+        rng = np.random.default_rng(self.random_state)
+        k = self._resolve_directions(d)
+
+        # Optional whitening pre-transform.
+        if self.whiten:
+            self.whitener_ = PCARotation(whiten=True).fit(X)
+            Xw = self.whitener_.transform(X)
+        else:
+            self.whitener_ = None
+            Xw = X
+
+        crit = StoppingCriterion(
+            metric=self.stopping_metric,
+            patience=self.patience,
+            validation_fraction=self.validation_fraction,
+            random_state=self.random_state,
+        )
+        X_train, X_val = crit.split(Xw, random_state=self.random_state)
+
+        self.layers_: list[SIGLayer] = []
+        log_det_val = np.zeros(X_val.shape[0])
+        R_train = X_train.copy()
+        R_val = X_val.copy()
+
+        for _ in range(self.n_layers):
+            target = (
+                rng.standard_normal(R_train.shape)
+                if self.direction_method == "stiefel"
+                else None
+            )
+            layer = SIGLayer(
+                n_directions=k,
+                n_knots=self.n_knots,
+                alpha=self.alpha,
+                direction_method=self.direction_method,
+                stiefel_lr=self.stiefel_lr,
+                stiefel_max_iter=self.stiefel_max_iter,
+                kde_bandwidth=self.kde_bandwidth,
+                random_state=int(rng.integers(2**31)),
+            )
+            layer.fit(R_train, X_target=target)
+            R_train, _ = layer.transform(R_train)
+            R_val, ld_val = layer.transform(R_val)
+            log_det_val += ld_val
+            self.layers_.append(layer)
+
+            if crit.update(R_val, log_det=log_det_val):
+                break
+
+        self.stopping_criterion_ = crit
+        self.n_layers_ = len(self.layers_)
+        return self
+
+    def transform(self, X: np.ndarray) -> np.ndarray:
+        """Map data to the (approximately) Gaussian latent space."""
+        check_is_fitted(self)
+        Xt = validate_data(self, X, reset=False)
+        if self.whitener_ is not None:
+            Xt = self.whitener_.transform(Xt)
+        for layer in self.layers_:
+            Xt, _ = layer.transform(Xt)
+        return Xt
+
+    def inverse_transform(self, Z: np.ndarray) -> np.ndarray:
+        """Map latent-space data back to the original input space."""
+        check_is_fitted(self)
+        Xt = np.asarray(Z, dtype=float)
+        for layer in reversed(self.layers_):
+            Xt = layer.inverse_transform(Xt)
+        if self.whitener_ is not None:
+            Xt = self.whitener_.inverse_transform(Xt)
+        return Xt
+
+    def score_samples(self, X: np.ndarray) -> np.ndarray:
+        """Per-sample log-likelihood via the change-of-variables formula."""
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False)
+        log_det = np.zeros(X.shape[0])
+        if self.whitener_ is not None:
+            log_det += self.whitener_.log_det_jacobian(X)
+            Xt = self.whitener_.transform(X)
+        else:
+            Xt = X.copy()
+        for layer in self.layers_:
+            Xt, ld = layer.transform(Xt)
+            log_det += ld
+        log_pz = np.sum(stats.norm.logpdf(Xt), axis=1)
+        return log_pz + log_det
+
+    def score(self, X: np.ndarray, y=None) -> float:
+        """Mean per-sample log-likelihood in nats."""
+        return float(np.mean(self.score_samples(X)))
+
+    def sample(self, n_samples: int, random_state: int | None = None) -> np.ndarray:
+        """Generate samples by inverting Gaussian noise through the flow."""
+        check_is_fitted(self)
+        rng = np.random.default_rng(random_state)
+        Z = rng.standard_normal((n_samples, self.n_features_in_))
+        return self.inverse_transform(Z)
+
+
+class GIS(_BaseSliced):
+    """Gaussianization via Iterative Slicing (Dai & Seljak 2020).
+
+    Maps arbitrary distributions to a standard Gaussian via greedy layer
+    stacking.  Each layer finds optimal projection directions and applies 1D
+    spline Gaussianization along them.  Oriented toward density estimation:
+    the headline methods are :meth:`transform` and :meth:`score_samples`.
+
+    Parameters
+    ----------
+    n_layers : int, default 500
+        Maximum number of layers (early-stopped via ``patience``).
+    n_directions : int or None, default None
+        Directions per layer ``K``.  ``None`` selects ``D // 2``.
+    n_knots : int, default 1000
+        Knots per 1D spline.
+    alpha : float, default 1e-3
+        Lower clip on spline derivatives.
+    whiten : bool, default True
+        Apply a PCA whitening pre-transform before stacking layers.
+    direction_method : {"stiefel", "random"}, default "stiefel"
+        Projection-direction strategy.
+    stopping_metric : {"log_likelihood", "swd", "total_correlation"}, default "log_likelihood"
+        Signal driving early stopping.
+    validation_fraction : float, default 0.2
+        Held-out fraction for the stopping criterion.
+    patience : int, default 10
+        Non-improving layers tolerated before stopping.
+    stiefel_lr : float, default 1.0
+        Initial Stiefel line-search step size.
+    stiefel_max_iter : int, default 100
+        Maximum Stiefel iterations per layer.
+    kde_bandwidth : str, float, or None, default None
+        Bandwidth for each spline's KDE.
+    random_state : int or None, optional
+        Seed for reproducibility.
+
+    Attributes
+    ----------
+    layers_ : list of SIGLayer
+        Fitted layers in forward (data -> Gaussian) order.
+    whitener_ : PCARotation or None
+        Fitted whitening pre-transform.
+    stopping_criterion_ : StoppingCriterion
+        The fitted stopping tracker (exposes ``history_``, ``best_iter_``).
+    n_features_in_ : int
+        Number of features seen during ``fit``.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from rbig import GIS
+    >>> rng = np.random.default_rng(0)
+    >>> X = rng.standard_normal((400, 3))
+    >>> model = GIS(n_layers=5, random_state=0).fit(X)
+    >>> Z = model.transform(X)
+    >>> Z.shape
+    (400, 3)
+    """
+
+    def __init__(
+        self,
+        n_layers: int = 500,
+        n_directions: int | None = None,
+        n_knots: int = 1000,
+        alpha: float = 1e-3,
+        whiten: bool = True,
+        direction_method: str = "stiefel",
+        stopping_metric: str = "log_likelihood",
+        validation_fraction: float = 0.2,
+        patience: int = 10,
+        stiefel_lr: float = 1.0,
+        stiefel_max_iter: int = 100,
+        kde_bandwidth: str | float | None = None,
+        random_state: int | None = None,
+    ):
+        self.n_layers = n_layers
+        self.n_directions = n_directions
+        self.n_knots = n_knots
+        self.alpha = alpha
+        self.whiten = whiten
+        self.direction_method = direction_method
+        self.stopping_metric = stopping_metric
+        self.validation_fraction = validation_fraction
+        self.patience = patience
+        self.stiefel_lr = stiefel_lr
+        self.stiefel_max_iter = stiefel_max_iter
+        self.kde_bandwidth = kde_bandwidth
+        self.random_state = random_state
+
+
+class SIG(_BaseSliced):
+    """Sliced Iterative Gaussianization (Dai & Seljak 2020).
+
+    The generative-oriented sibling of :class:`GIS`.  It builds the same
+    sliced-Gaussianization flow but is configured and documented for
+    sampling: draw ``z ~ N(0, I)`` and push it through
+    :meth:`inverse_transform` (or :meth:`sample`) to obtain data-like
+    samples.  Defaults to a sliced-Wasserstein stopping signal, which tracks
+    sample quality more directly than the validation log-likelihood.
+
+    Parameters
+    ----------
+    n_layers : int, default 500
+        Maximum number of layers (early-stopped via ``patience``).
+    n_directions : int or None, default None
+        Directions per layer ``K``.  ``None`` selects ``D // 2``.
+    n_knots : int, default 1000
+        Knots per 1D spline.
+    alpha : float, default 1e-3
+        Lower clip on spline derivatives.
+    whiten : bool, default True
+        Apply a PCA whitening pre-transform.
+    direction_method : {"stiefel", "random"}, default "stiefel"
+        Projection-direction strategy.
+    stopping_metric : {"log_likelihood", "swd", "total_correlation"}, default "swd"
+        Signal driving early stopping.
+    validation_fraction : float, default 0.2
+        Held-out fraction for the stopping criterion.
+    patience : int, default 10
+        Non-improving layers tolerated before stopping.
+    stiefel_lr : float, default 1.0
+        Initial Stiefel line-search step size.
+    stiefel_max_iter : int, default 100
+        Maximum Stiefel iterations per layer.
+    kde_bandwidth : str, float, or None, default None
+        Bandwidth for each spline's KDE.
+    random_state : int or None, optional
+        Seed for reproducibility.
+
+    Attributes
+    ----------
+    layers_ : list of SIGLayer
+        Fitted layers in forward (data -> Gaussian) order; sampling applies
+        them in reverse.
+    whitener_ : PCARotation or None
+        Fitted whitening pre-transform.
+    stopping_criterion_ : StoppingCriterion
+        The fitted stopping tracker.
+    n_features_in_ : int
+        Number of features seen during ``fit``.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from rbig import SIG
+    >>> rng = np.random.default_rng(0)
+    >>> X = rng.standard_normal((400, 2))
+    >>> model = SIG(n_layers=5, random_state=0).fit(X)
+    >>> samples = model.sample(50, random_state=1)
+    >>> samples.shape
+    (50, 2)
+    """
+
+    def __init__(
+        self,
+        n_layers: int = 500,
+        n_directions: int | None = None,
+        n_knots: int = 1000,
+        alpha: float = 1e-3,
+        whiten: bool = True,
+        direction_method: str = "stiefel",
+        stopping_metric: str = "swd",
+        validation_fraction: float = 0.2,
+        patience: int = 10,
+        stiefel_lr: float = 1.0,
+        stiefel_max_iter: int = 100,
+        kde_bandwidth: str | float | None = None,
+        random_state: int | None = None,
+    ):
+        self.n_layers = n_layers
+        self.n_directions = n_directions
+        self.n_knots = n_knots
+        self.alpha = alpha
+        self.whiten = whiten
+        self.direction_method = direction_method
+        self.stopping_metric = stopping_metric
+        self.validation_fraction = validation_fraction
+        self.patience = patience
+        self.stiefel_lr = stiefel_lr
+        self.stiefel_max_iter = stiefel_max_iter
+        self.kde_bandwidth = kde_bandwidth
+        self.random_state = random_state

--- a/rbig/_src/sliced.py
+++ b/rbig/_src/sliced.py
@@ -242,6 +242,16 @@ class _BaseSliced(TransformerMixin, BaseEstimator):
         n, d = X.shape
         if n < 2:
             raise ValueError(f"Need at least 2 samples, got {n}.")
+        if self.whiten and n <= d:
+            # PCA(whiten=True) keeps only min(n_samples, n_features) (and at
+            # most n_samples - 1) components, so wide data yields a
+            # rank-deficient, non-square whitening that breaks the bijection
+            # (inverse_transform / sample would mismatch shapes).
+            raise ValueError(
+                f"whiten=True requires n_samples > n_features for a full-rank "
+                f"square whitening; got n_samples={n}, n_features={d}. "
+                f"Pass whiten=False for wide data."
+            )
         self.n_features_in_ = d
         rng = np.random.default_rng(self.random_state)
         k = self._resolve_directions(d)
@@ -291,6 +301,12 @@ class _BaseSliced(TransformerMixin, BaseEstimator):
 
             if crit.update(R_val, log_det=log_det_val):
                 break
+
+        # Keep only the prefix up to the best validation iterate.  Any layers
+        # appended after the metric peaked (during the patience window) only
+        # make the selected stopping metric worse, so they are discarded.
+        if crit.best_iter_ >= 0:
+            self.layers_ = self.layers_[: crit.best_iter_ + 1]
 
         self.stopping_criterion_ = crit
         self.n_layers_ = len(self.layers_)

--- a/rbig/_src/spline.py
+++ b/rbig/_src/spline.py
@@ -1,0 +1,319 @@
+"""Shared 1D monotonic rational-quadratic (RQ) spline primitive.
+
+This module provides :class:`RQSpline`, a one-dimensional, strictly
+monotonic rational-quadratic spline used as the core 1D Gaussianization
+transform throughout the library.  The same primitive is applied whether
+the input is a raw feature dimension (``X[:, k]``) or a projected slice
+(``X @ a_k``); only the data fed in differs.
+
+The forward map sends data to an (approximately) standard-normal variable
+by composing an estimated marginal CDF with the Gaussian quantile
+function::
+
+    z = Phi ^ {-1}(F_hat(x))
+
+The CDF ``F_hat`` is estimated with a Gaussian kernel density estimate
+(KDE).  Knots are placed on the data support; the target ``z`` values are
+the Gaussian quantiles ``Phi^{-1}(F_hat(x_knot))``; and the spline
+derivatives at the knots are the analytic Gaussianization derivatives::
+
+    g'(x) = f_hat(x) / phi(g(x))
+
+which are strictly positive, guaranteeing a monotone (hence invertible)
+transform.  Between knots the map is a rational-quadratic interpolant
+(Durkan et al. 2019); outside the outermost knots it extends linearly,
+so both the forward map and its inverse are analytic everywhere.
+
+References
+----------
+Durkan, C., Bekasov, A., Murray, I., & Papamakarios, G. (2019). Neural
+Spline Flows. *NeurIPS*. https://arxiv.org/abs/1906.04032
+
+Dai, B., & Seljak, U. (2020). Sliced Iterative Normalizing Flows.
+https://arxiv.org/abs/2007.00674
+
+sinflow ``MonotonicRationalQuadraticSpline``:
+https://github.com/minaskar/sinflow
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy import stats
+from scipy.special import ndtri
+
+
+class RQSpline:
+    """Strictly monotonic 1D rational-quadratic spline for Gaussianization.
+
+    A single fitted instance represents one scalar bijection ``x -> z`` that
+    maps a 1D sample to an approximately standard-normal variable, together
+    with its analytic inverse and log-derivative.
+
+    Parameters
+    ----------
+    n_knots : int, default 1000
+        Number of spline knots placed across the data support.  Capped at
+        the number of available samples during :meth:`fit`.
+    kde_bw : str, float, or None, default None
+        Bandwidth selection passed to :class:`scipy.stats.gaussian_kde`
+        when estimating the CDF.  ``None`` uses Scott's rule.
+    eps : float, default 1e-6
+        Clipping margin applied to CDF values before the probit
+        ``Phi^{-1}`` to keep the target knots finite.
+    min_derivative : float, default 1e-3
+        Lower clip on the spline knot derivatives.  Prevents zero or
+        negative slopes (which would break monotonicity) in regions of
+        vanishing estimated density.
+
+    Attributes
+    ----------
+    x_knots_ : np.ndarray of shape (n_bins + 1,)
+        Strictly increasing knot positions in data space.
+    y_knots_ : np.ndarray of shape (n_bins + 1,)
+        Strictly increasing knot positions in Gaussian (latent) space.
+    derivatives_ : np.ndarray of shape (n_bins + 1,)
+        Positive spline derivatives ``dz/dx`` at each knot.
+    identity_ : bool
+        True when the input had no spread (constant feature); the spline
+        then falls back to a centred identity map.
+
+    Notes
+    -----
+    The rational-quadratic interpolant on bin ``k`` (Durkan et al. 2019),
+    with bin width ``w = x_{k+1} - x_k``, height ``h = z_{k+1} - z_k``,
+    slope ``s = h / w``, knot derivatives ``d_k, d_{k+1}`` and local
+    coordinate ``xi = (x - x_k) / w`` is::
+
+        z = z_k + h * (s * xi^2 + d_k * xi * (1 - xi)) / D
+        D = s + (d_{k+1} + d_k - 2 s) * xi * (1 - xi)
+
+    with derivative::
+
+        dz/dx = s^2 * (d_{k+1} xi^2 + 2 s xi (1-xi) + d_k (1-xi)^2) / D^2
+
+    The inverse solves a quadratic in ``xi`` analytically, so
+    ``inverse(forward(x)) == x`` to numerical precision.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from rbig._src.spline import RQSpline
+    >>> rng = np.random.default_rng(0)
+    >>> x = rng.standard_normal(2000)
+    >>> spline = RQSpline(n_knots=200).fit(x)
+    >>> z, log_dzdx = spline.forward(x)
+    >>> x_rec, _ = spline.inverse(z)
+    >>> bool(np.allclose(x_rec, x, atol=1e-4))
+    True
+    """
+
+    def __init__(
+        self,
+        n_knots: int = 1000,
+        kde_bw: str | float | None = None,
+        eps: float = 1e-6,
+        min_derivative: float = 1e-3,
+    ):
+        self.n_knots = n_knots
+        self.kde_bw = kde_bw
+        self.eps = eps
+        self.min_derivative = min_derivative
+
+    def fit(
+        self,
+        x: np.ndarray,
+        n_knots: int | None = None,
+        kde_bw: str | float | None = None,
+    ) -> RQSpline:
+        """Estimate knots and derivatives from 1D data.
+
+        Parameters
+        ----------
+        x : np.ndarray of shape (n_samples,)
+            One-dimensional training data (a raw feature or a projected
+            slice).  Multi-dimensional input is flattened.
+        n_knots : int or None, optional
+            Override for ``self.n_knots`` for this fit.
+        kde_bw : str, float, or None, optional
+            Override for ``self.kde_bw`` for this fit.
+
+        Returns
+        -------
+        self : RQSpline
+            The fitted spline.
+        """
+        x = np.asarray(x, dtype=float).ravel()
+        n_knots = int(self.n_knots if n_knots is None else n_knots)
+        kde_bw = self.kde_bw if kde_bw is None else kde_bw
+
+        x_min, x_max = float(x.min()), float(x.max())
+        # Degenerate (constant) feature: fall back to a centred identity map.
+        if x_max - x_min <= 0.0 or x.size < 2:
+            self.identity_ = True
+            self.x_offset_ = float(x.mean()) if x.size else 0.0
+            self.x_knots_ = np.array([x_min - 1.0, x_min, x_min + 1.0])
+            self.y_knots_ = self.x_knots_ - self.x_offset_
+            self.derivatives_ = np.ones_like(self.x_knots_)
+            return self
+        self.identity_ = False
+
+        # Use at most n_samples knots; need at least two bins.
+        n_knots = max(3, min(n_knots, x.size))
+
+        kde = stats.gaussian_kde(x, bw_method=kde_bw)
+        bw = float(np.sqrt(kde.covariance[0, 0]))
+
+        # Knot positions on a regular grid over the data support.
+        x_knots = np.linspace(x_min, x_max, n_knots)
+
+        # Analytic Gaussian-KDE CDF: F(t) = mean_i Phi((t - x_i) / bw).
+        cdf = stats.norm.cdf((x_knots[:, None] - x[None, :]) / bw).mean(axis=1)
+        # Enforce monotonicity and keep away from the probit's infinities.
+        cdf = np.maximum.accumulate(cdf)
+        cdf = np.clip(cdf, self.eps, 1.0 - self.eps)
+        y_knots = ndtri(cdf)
+
+        # Drop knots that are not strictly increasing in z (the CDF can
+        # saturate to the clip bounds in the tails, producing ties).
+        keep = np.concatenate([[True], np.diff(y_knots) > 0.0])
+        x_knots, y_knots = x_knots[keep], y_knots[keep]
+        if x_knots.size < 2:
+            # KDE produced a degenerate CDF; fall back to identity.
+            self.identity_ = True
+            self.x_offset_ = float(x.mean())
+            self.x_knots_ = np.array([x_min - 1.0, x_min, x_min + 1.0])
+            self.y_knots_ = self.x_knots_ - self.x_offset_
+            self.derivatives_ = np.ones_like(self.x_knots_)
+            return self
+
+        # Gaussianization derivative g'(x) = f(x) / phi(g(x)) at each knot.
+        pdf = kde(x_knots)
+        derivatives = pdf / np.maximum(stats.norm.pdf(y_knots), 1e-300)
+        derivatives = np.clip(derivatives, self.min_derivative, 1.0 / self.eps)
+
+        self.x_knots_ = x_knots
+        self.y_knots_ = y_knots
+        self.derivatives_ = derivatives
+        return self
+
+    def forward(self, x: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """Map data to Gaussian space: ``z = g(x)``.
+
+        Parameters
+        ----------
+        x : np.ndarray of shape (n_samples,)
+            Input values in data space.
+
+        Returns
+        -------
+        z : np.ndarray of shape (n_samples,)
+            Gaussianized values.
+        log_dz_dx : np.ndarray of shape (n_samples,)
+            Per-sample log absolute derivative ``log|dz/dx|``.
+        """
+        x = np.asarray(x, dtype=float).ravel()
+        if self.identity_:
+            return x - self.x_offset_, np.zeros_like(x)
+
+        xk, yk, d = self.x_knots_, self.y_knots_, self.derivatives_
+        z = np.empty_like(x)
+        log_dz_dx = np.empty_like(x)
+
+        left = x < xk[0]
+        right = x > xk[-1]
+        interior = ~(left | right)
+
+        # Linear tails extend the boundary knot derivative.
+        z[left] = yk[0] + d[0] * (x[left] - xk[0])
+        log_dz_dx[left] = np.log(d[0])
+        z[right] = yk[-1] + d[-1] * (x[right] - xk[-1])
+        log_dz_dx[right] = np.log(d[-1])
+
+        if np.any(interior):
+            xi_ = x[interior]
+            # Bin index k such that xk[k] <= x < xk[k+1].
+            k = np.searchsorted(xk, xi_, side="right") - 1
+            k = np.clip(k, 0, xk.size - 2)
+            w = xk[k + 1] - xk[k]
+            h = yk[k + 1] - yk[k]
+            s = h / w
+            dk, dk1 = d[k], d[k + 1]
+            xi = (xi_ - xk[k]) / w
+            xi1 = 1.0 - xi
+
+            denom = s + (dk1 + dk - 2.0 * s) * xi * xi1
+            z[interior] = yk[k] + h * (s * xi * xi + dk * xi * xi1) / denom
+            deriv = (
+                s
+                * s
+                * (dk1 * xi * xi + 2.0 * s * xi * xi1 + dk * xi1 * xi1)
+                / (denom * denom)
+            )
+            log_dz_dx[interior] = np.log(np.maximum(deriv, 1e-300))
+
+        return z, log_dz_dx
+
+    def inverse(self, z: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """Map Gaussian space back to data space: ``x = g^{-1}(z)``.
+
+        Parameters
+        ----------
+        z : np.ndarray of shape (n_samples,)
+            Values in Gaussian (latent) space.
+
+        Returns
+        -------
+        x : np.ndarray of shape (n_samples,)
+            Recovered data-space values.
+        log_dx_dz : np.ndarray of shape (n_samples,)
+            Per-sample log absolute derivative ``log|dx/dz|`` of the inverse.
+        """
+        z = np.asarray(z, dtype=float).ravel()
+        if self.identity_:
+            return z + self.x_offset_, np.zeros_like(z)
+
+        xk, yk, d = self.x_knots_, self.y_knots_, self.derivatives_
+        x = np.empty_like(z)
+        log_dx_dz = np.empty_like(z)
+
+        left = z < yk[0]
+        right = z > yk[-1]
+        interior = ~(left | right)
+
+        x[left] = xk[0] + (z[left] - yk[0]) / d[0]
+        log_dx_dz[left] = -np.log(d[0])
+        x[right] = xk[-1] + (z[right] - yk[-1]) / d[-1]
+        log_dx_dz[right] = -np.log(d[-1])
+
+        if np.any(interior):
+            zi = z[interior]
+            k = np.searchsorted(yk, zi, side="right") - 1
+            k = np.clip(k, 0, yk.size - 2)
+            w = xk[k + 1] - xk[k]
+            h = yk[k + 1] - yk[k]
+            s = h / w
+            dk, dk1 = d[k], d[k + 1]
+            delta = dk1 + dk - 2.0 * s
+            eta = zi - yk[k]
+
+            # Solve the quadratic a*xi^2 + b*xi + c = 0 for xi in [0, 1].
+            a = h * (s - dk) + eta * delta
+            b = h * dk - eta * delta
+            c = -s * eta
+            discriminant = np.maximum(b * b - 4.0 * a * c, 0.0)
+            xi = 2.0 * c / (-b - np.sqrt(discriminant))
+            xi = np.clip(xi, 0.0, 1.0)
+            xi1 = 1.0 - xi
+
+            x[interior] = xk[k] + xi * w
+            denom = s + delta * xi * xi1
+            deriv = (
+                s
+                * s
+                * (dk1 * xi * xi + 2.0 * s * xi * xi1 + dk * xi1 * xi1)
+                / (denom * denom)
+            )
+            log_dx_dz[interior] = -np.log(np.maximum(deriv, 1e-300))
+
+        return x, log_dx_dz

--- a/rbig/_src/stiefel.py
+++ b/rbig/_src/stiefel.py
@@ -172,8 +172,12 @@ def max_sliced_wasserstein_directions(
     eye = np.eye(d)
 
     for _ in range(max_iter):
-        # Skew-symmetric generator; the "+" sign ascends the objective.
-        W = grad @ A.T - A @ grad.T
+        # Skew-symmetric Cayley generator.  With G the gradient of the
+        # *maximization* objective, the path C(tau) = (I + tau/2 W)^{-1}
+        # (I - tau/2 W) has dF/dtau|_0 = +||W||_F^2 / 2 -- i.e. it ascends
+        # the K-SWD -- precisely when W = A G^T - G A^T.  The opposite sign
+        # (G A^T - A G^T) descends; see Wen & Yin (2013).
+        W = A @ grad.T - grad @ A.T
         norm_w = np.linalg.norm(W)
         if norm_w < tol:
             break

--- a/rbig/_src/stiefel.py
+++ b/rbig/_src/stiefel.py
@@ -1,0 +1,207 @@
+"""Stiefel-manifold optimization for projection directions.
+
+The Sliced Iterative Gaussianization family finds, at each layer, a small
+set of ``K`` orthonormal directions along which the data is *most*
+non-Gaussian, then Gaussianizes those 1D slices.  "Most non-Gaussian" is
+measured by the **K-Sliced Wasserstein Distance** (K-SWD): the mean
+1-Wasserstein distance between the data projected onto each direction and
+a Gaussian reference projected onto the same direction.
+
+Maximizing the K-SWD over the set of orthonormal frames is an optimization
+on the Stiefel manifold ``St(D, K) = {A in R^{D x K} : A^T A = I_K}``.  We
+use the Cayley-transform curvilinear update of Wen & Yin (2013) with a
+backtracking line search, which keeps every iterate exactly orthonormal.
+
+References
+----------
+Wen, Z., & Yin, W. (2013). A feasible method for optimization with
+orthogonality constraints. *Mathematical Programming*, 142, 397-434.
+
+Dai, B., & Seljak, U. (2020). Sliced Iterative Normalizing Flows.
+https://arxiv.org/abs/2007.00674
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def wasserstein_1d(x: np.ndarray, y: np.ndarray) -> float:
+    """1-Wasserstein (earth-mover) distance between two 1D samples.
+
+    Computed in closed form from the sorted order statistics; sample sizes
+    need not match (quantiles are compared on a shared grid).
+
+    Parameters
+    ----------
+    x, y : np.ndarray
+        One-dimensional samples (flattened if not already 1D).
+
+    Returns
+    -------
+    distance : float
+        The 1-Wasserstein distance ``W_1(x, y) >= 0``.
+    """
+    x = np.sort(np.asarray(x, dtype=float).ravel())
+    y = np.sort(np.asarray(y, dtype=float).ravel())
+    if x.size == y.size:
+        return float(np.mean(np.abs(x - y)))
+    n = max(x.size, y.size)
+    q = (np.arange(n) + 0.5) / n
+    return float(np.mean(np.abs(np.quantile(x, q) - np.quantile(y, q))))
+
+
+def random_orthogonal_directions(
+    n_features: int, n_directions: int, random_state: int | None = None
+) -> np.ndarray:
+    """Draw ``K`` random orthonormal directions in ``R^D`` via QR.
+
+    Parameters
+    ----------
+    n_features : int
+        Ambient dimension ``D``.
+    n_directions : int
+        Number of directions ``K`` (capped at ``D``).
+    random_state : int or None, optional
+        Seed for reproducibility.
+
+    Returns
+    -------
+    A : np.ndarray of shape (n_features, n_directions)
+        Matrix with orthonormal columns (``A.T @ A == I_K``).
+    """
+    rng = np.random.default_rng(random_state)
+    k = min(n_directions, n_features)
+    m = rng.standard_normal((n_features, k))
+    q, r = np.linalg.qr(m)
+    # Fix column signs so the result is deterministic given the seed.
+    q = q * np.sign(np.diag(r))
+    return q[:, :k]
+
+
+def _subsample(X: np.ndarray, n: int, rng: np.random.Generator) -> np.ndarray:
+    """Return ``n`` rows of ``X`` (random subset without replacement)."""
+    if X.shape[0] == n:
+        return X
+    idx = rng.choice(X.shape[0], size=n, replace=False)
+    return X[idx]
+
+
+def _kswd_objective_and_grad(
+    A: np.ndarray, X: np.ndarray, Z: np.ndarray
+) -> tuple[float, np.ndarray]:
+    """Mean per-direction ``W_1`` and its Euclidean gradient w.r.t. ``A``.
+
+    ``X`` and ``Z`` must have the same number of rows ``n`` so the sorted
+    projections pair up one-to-one.  The (sub)gradient of the 1D
+    Wasserstein distance w.r.t. a projection direction ``a`` is
+    ``(1/n) sum_i sign(p_i - q_i) (x_i - z_i)`` evaluated on the matched
+    sorted samples.
+    """
+    n, k = X.shape[0], A.shape[1]
+    P = X @ A
+    Q = Z @ A
+    obj = 0.0
+    grad = np.zeros_like(A)
+    for j in range(k):
+        ox = np.argsort(P[:, j])
+        oz = np.argsort(Q[:, j])
+        diff = P[ox, j] - Q[oz, j]
+        obj += np.mean(np.abs(diff))
+        s = np.sign(diff)
+        grad[:, j] = (X[ox].T @ s - Z[oz].T @ s) / n
+    return obj / k, grad / k
+
+
+def max_sliced_wasserstein_directions(
+    X: np.ndarray,
+    Z_target: np.ndarray,
+    n_directions: int,
+    max_iter: int = 100,
+    lr: float = 1.0,
+    tol: float = 1e-6,
+    random_state: int | None = None,
+    return_history: bool = False,
+) -> np.ndarray | tuple[np.ndarray, list[float]]:
+    """Find ``K`` orthonormal directions maximizing the K-SWD.
+
+    Maximizes the mean 1-Wasserstein distance between ``X`` and
+    ``Z_target`` projected onto each of ``K`` orthonormal directions, using
+    a Cayley-transform curvilinear search on the Stiefel manifold.  The
+    returned directions are those along which the two distributions differ
+    most -- i.e. the directions most worth Gaussianizing next.
+
+    Parameters
+    ----------
+    X : np.ndarray of shape (n_samples, n_features)
+        Current data sample.
+    Z_target : np.ndarray of shape (n_target, n_features)
+        Reference sample (a Gaussian sample for GIS; data for SIG).
+    n_directions : int
+        Number of directions ``K`` to return (capped at ``n_features``).
+    max_iter : int, default 100
+        Maximum number of curvilinear-search iterations.
+    lr : float, default 1.0
+        Initial step size for the backtracking line search.
+    tol : float, default 1e-6
+        Stop when the objective improves by less than ``tol``.
+    random_state : int or None, optional
+        Seed controlling the initial frame and any subsampling.
+    return_history : bool, default False
+        If True, also return the list of objective values per iteration.
+
+    Returns
+    -------
+    A : np.ndarray of shape (n_features, n_directions)
+        Orthonormal projection directions (``A.T @ A == I_K``).
+    history : list of float
+        Objective value at each accepted iterate.  Only returned when
+        ``return_history=True``.
+    """
+    rng = np.random.default_rng(random_state)
+    d = X.shape[1]
+    k = min(n_directions, d)
+
+    n = min(X.shape[0], Z_target.shape[0])
+    Xs = _subsample(X, n, rng)
+    Zs = _subsample(Z_target, n, rng)
+
+    A = random_orthogonal_directions(d, k, random_state=rng.integers(2**31))
+    obj, grad = _kswd_objective_and_grad(A, Xs, Zs)
+    history = [obj]
+    eye = np.eye(d)
+
+    for _ in range(max_iter):
+        # Skew-symmetric generator; the "+" sign ascends the objective.
+        W = grad @ A.T - A @ grad.T
+        norm_w = np.linalg.norm(W)
+        if norm_w < tol:
+            break
+
+        tau = lr
+        accepted = False
+        for _ls in range(25):
+            cayley = np.linalg.solve(eye + (tau / 2.0) * W, eye - (tau / 2.0) * W)
+            A_new = cayley @ A
+            obj_new, grad_new = _kswd_objective_and_grad(A_new, Xs, Zs)
+            if obj_new > obj:
+                accepted = True
+                break
+            tau *= 0.5
+
+        if not accepted:
+            break
+
+        improvement = obj_new - obj
+        A, obj, grad = A_new, obj_new, grad_new
+        history.append(obj)
+        if improvement < tol:
+            break
+
+    # Re-orthonormalize to clean up any accumulated numerical drift.
+    A, _ = np.linalg.qr(A)
+    A = A[:, :k]
+
+    if return_history:
+        return A, history
+    return A

--- a/tests/test_convergence.py
+++ b/tests/test_convergence.py
@@ -1,0 +1,83 @@
+"""Tests for the shared StoppingCriterion module."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from rbig._src.convergence import StoppingCriterion
+
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng(0)
+
+
+def test_invalid_metric():
+    with pytest.raises(ValueError, match="Unknown metric"):
+        StoppingCriterion(metric="nope")
+
+
+@pytest.mark.parametrize("metric", ["log_likelihood", "swd", "total_correlation"])
+def test_metric_returns_finite(rng, metric):
+    crit = StoppingCriterion(metric=metric, random_state=0)
+    X = rng.standard_normal((300, 3))
+    crit.update(X, log_det=np.zeros(300))
+    assert np.isfinite(crit.best_score())
+    assert len(crit.history_) == 1
+
+
+def test_split_shapes(rng):
+    crit = StoppingCriterion(validation_fraction=0.25)
+    X = rng.standard_normal((400, 4))
+    X_tr, X_val = crit.split(X, random_state=0)
+    assert X_tr.shape[0] == 300
+    assert X_val.shape[0] == 100
+    assert X_tr.shape[1] == X_val.shape[1] == 4
+
+
+def test_split_zero_fraction_returns_full(rng):
+    crit = StoppingCriterion(validation_fraction=0.0)
+    X = rng.standard_normal((50, 2))
+    X_tr, X_val = crit.split(X)
+    assert X_tr.shape == X_val.shape == X.shape
+
+
+def test_early_stop_triggers_with_patience():
+    crit = StoppingCriterion(
+        metric="total_correlation", patience=3, validation_fraction=0.0
+    )
+    rng = np.random.default_rng(1)
+    # Same data each iteration => metric never improves after the first.
+    X = rng.standard_normal((300, 3))
+    stops = [crit.update(X) for _ in range(6)]
+    # First update sets the baseline; then 3 non-improving updates stop it.
+    assert stops[:3] == [False, False, False]
+    assert stops[3] is True
+
+
+def test_log_likelihood_improves_when_more_gaussian(rng):
+    crit = StoppingCriterion(metric="log_likelihood", validation_fraction=0.0)
+    # A poorly scaled representation has lower log-likelihood than N(0, I).
+    bad = rng.standard_normal((500, 3)) * 5.0
+    good = rng.standard_normal((500, 3))
+    crit.update(good, log_det=np.zeros(500))
+    s_good = crit.history_[-1]
+    crit2 = StoppingCriterion(metric="log_likelihood", validation_fraction=0.0)
+    crit2.update(bad, log_det=np.zeros(500))
+    s_bad = crit2.history_[-1]
+    assert s_good > s_bad
+
+
+def test_best_score_before_update_raises():
+    crit = StoppingCriterion()
+    with pytest.raises(ValueError, match="No updates"):
+        crit.best_score()
+
+
+def test_swd_smaller_for_gaussian(rng):
+    crit_g = StoppingCriterion(metric="swd", random_state=0, validation_fraction=0.0)
+    crit_g.update(rng.standard_normal((1000, 3)))
+    crit_b = StoppingCriterion(metric="swd", random_state=0, validation_fraction=0.0)
+    crit_b.update(rng.exponential(1.0, (1000, 3)))
+    assert crit_g.best_score() < crit_b.best_score()

--- a/tests/test_sliced.py
+++ b/tests/test_sliced.py
@@ -1,0 +1,181 @@
+"""Tests for Sliced Iterative Gaussianization (SIGLayer, GIS, SIG)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from sklearn.base import clone
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+from rbig import GIS, SIG, SIGLayer
+
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng(42)
+
+
+@pytest.fixture
+def banana(rng):
+    """Banana-shaped 2D distribution."""
+    X = rng.standard_normal((600, 2))
+    X[:, 1] += 0.5 * X[:, 0] ** 2
+    return X
+
+
+@pytest.fixture
+def gmm_2d(rng):
+    """Two-component 2D Gaussian mixture."""
+    n = 600
+    comp = rng.integers(0, 2, n)
+    means = np.array([[-3.0, -3.0], [3.0, 3.0]])
+    X = rng.standard_normal((n, 2)) + means[comp]
+    return X
+
+
+@pytest.fixture
+def high_d(rng):
+    """Moderate-dimensional correlated data."""
+    d = 20
+    A = rng.standard_normal((d, d))
+    return rng.standard_normal((400, d)) @ A
+
+
+# ── SIGLayer ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("method", ["stiefel", "random"])
+def test_layer_roundtrip(banana, method):
+    layer = SIGLayer(n_directions=2, direction_method=method, random_state=0)
+    layer.fit(banana)
+    Z, log_det = layer.transform(banana)
+    Xr = layer.inverse_transform(Z)
+    np.testing.assert_allclose(Xr, banana, atol=1e-6)
+    assert log_det.shape == (banana.shape[0],)
+    assert np.all(np.isfinite(log_det))
+
+
+def test_layer_directions_orthonormal(high_d):
+    layer = SIGLayer(n_directions=5, direction_method="stiefel", random_state=0)
+    layer.fit(high_d)
+    assert layer.A_.shape == (20, 5)
+    np.testing.assert_allclose(layer.A_.T @ layer.A_, np.eye(5), atol=1e-7)
+
+
+def test_layer_makes_projection_more_gaussian(rng):
+    from scipy import stats
+
+    # Strongly non-Gaussian along the first axis.
+    X = rng.standard_normal((1000, 3))
+    X[:, 0] = rng.exponential(1.0, 1000)
+    layer = SIGLayer(n_directions=3, direction_method="stiefel", random_state=0)
+    layer.fit(X)
+    Z, _ = layer.transform(X)
+    # The most non-Gaussian projected direction should be more Gaussian after.
+    a = layer.A_[:, 0]
+    before = stats.shapiro(X @ a).statistic
+    after = stats.shapiro((Z @ a)[:500]).statistic
+    assert after >= before - 0.05
+
+
+# ── GIS ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("data", ["banana", "gmm_2d", "high_d"])
+def test_gis_transform_roundtrip(data, request):
+    X = request.getfixturevalue(data)
+    model = GIS(n_layers=10, random_state=0).fit(X)
+    Z = model.transform(X)
+    Xr = model.inverse_transform(Z)
+    assert Z.shape == X.shape
+    np.testing.assert_allclose(Xr, X, atol=1e-4)
+
+
+def test_gis_transform_is_gaussianish(gmm_2d):
+    model = GIS(n_layers=15, random_state=0).fit(gmm_2d)
+    Z = model.transform(gmm_2d)
+    assert np.all(np.abs(Z.mean(axis=0)) < 0.3)
+    assert np.all(np.abs(Z.std(axis=0) - 1.0) < 0.3)
+
+
+def test_gis_score_samples(banana):
+    model = GIS(n_layers=10, random_state=0).fit(banana)
+    ll = model.score_samples(banana)
+    assert ll.shape == (banana.shape[0],)
+    assert np.all(np.isfinite(ll))
+    assert np.isfinite(model.score(banana))
+
+
+def test_gis_sample_shape(banana):
+    model = GIS(n_layers=8, random_state=0).fit(banana)
+    samples = model.sample(150, random_state=1)
+    assert samples.shape == (150, 2)
+    assert np.all(np.isfinite(samples))
+
+
+def test_gis_early_stopping(rng):
+    # Already-Gaussian data should converge well before the layer cap.
+    X = rng.standard_normal((500, 3))
+    model = GIS(n_layers=200, patience=3, random_state=0).fit(X)
+    assert model.n_layers_ < 200
+
+
+def test_gis_random_directions(banana):
+    model = GIS(n_layers=10, direction_method="random", random_state=0).fit(banana)
+    Z = model.transform(banana)
+    Xr = model.inverse_transform(Z)
+    np.testing.assert_allclose(Xr, banana, atol=1e-4)
+
+
+def test_gis_no_whiten(banana):
+    model = GIS(n_layers=8, whiten=False, random_state=0).fit(banana)
+    assert model.whitener_ is None
+    Xr = model.inverse_transform(model.transform(banana))
+    np.testing.assert_allclose(Xr, banana, atol=1e-4)
+
+
+# ── SIG ──────────────────────────────────────────────────────────────────────
+
+
+def test_sig_sample_resembles_data(gmm_2d):
+    model = SIG(n_layers=15, random_state=0).fit(gmm_2d)
+    samples = model.sample(600, random_state=1)
+    assert samples.shape == (600, 2)
+    # Generated mean should be near the data mean (mixture centred near 0).
+    assert np.all(np.abs(samples.mean(axis=0) - gmm_2d.mean(axis=0)) < 1.5)
+
+
+def test_sig_inverse_roundtrip(banana):
+    model = SIG(n_layers=8, random_state=0).fit(banana)
+    Z = model.transform(banana)
+    Xr = model.inverse_transform(Z)
+    np.testing.assert_allclose(Xr, banana, atol=1e-4)
+
+
+def test_sig_score_finite(banana):
+    model = SIG(n_layers=8, random_state=0).fit(banana)
+    assert np.isfinite(model.score(banana))
+
+
+# ── sklearn compatibility ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("cls", [GIS, SIG])
+def test_get_params_clone(cls):
+    model = cls(n_layers=7, n_directions=2, random_state=3)
+    params = model.get_params()
+    assert params["n_layers"] == 7
+    assert params["random_state"] == 3
+    cloned = clone(model)
+    assert cloned.get_params()["n_layers"] == 7
+
+
+@pytest.mark.parametrize("cls", [GIS, SIG])
+def test_pipeline(cls, banana):
+    pipe = Pipeline(
+        [("scale", StandardScaler()), ("flow", cls(n_layers=5, random_state=0))]
+    )
+    pipe.fit(banana)
+    Z = pipe.transform(banana)
+    assert Z.shape == banana.shape

--- a/tests/test_sliced.py
+++ b/tests/test_sliced.py
@@ -135,6 +135,29 @@ def test_gis_no_whiten(banana):
     np.testing.assert_allclose(Xr, banana, atol=1e-4)
 
 
+def test_wide_data_whiten_rejected(rng):
+    # More features than samples: whitening cannot be square/full-rank.
+    X = rng.standard_normal((8, 20))
+    with pytest.raises(ValueError, match="n_samples > n_features"):
+        GIS(n_layers=3, random_state=0).fit(X)
+
+
+def test_wide_data_no_whiten_ok(rng):
+    # With whitening disabled, wide data still fits and round-trips.
+    X = rng.standard_normal((8, 20))
+    model = GIS(n_layers=3, whiten=False, direction_method="random", random_state=0)
+    model.fit(X)
+    Xr = model.inverse_transform(model.transform(X))
+    np.testing.assert_allclose(Xr, X, atol=1e-4)
+
+
+def test_layers_trimmed_to_best_iter(banana):
+    # Early stopping must discard the non-improving patience-window layers.
+    model = GIS(n_layers=60, patience=4, random_state=0).fit(banana)
+    assert len(model.layers_) == model.stopping_criterion_.best_iter_ + 1
+    assert model.n_layers_ == len(model.layers_)
+
+
 # ── SIG ──────────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_spline.py
+++ b/tests/test_spline.py
@@ -1,0 +1,98 @@
+"""Tests for the shared 1D rational-quadratic spline primitive."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from rbig._src.spline import RQSpline
+
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng(0)
+
+
+def test_forward_inverse_roundtrip(rng):
+    x = rng.standard_normal(2000)
+    spline = RQSpline(n_knots=300).fit(x)
+    z, _ = spline.forward(x)
+    x_rec, _ = spline.inverse(z)
+    np.testing.assert_allclose(x_rec, x, atol=1e-5)
+
+
+def test_roundtrip_skewed(rng):
+    # Skewed, strictly positive data.
+    x = rng.gamma(shape=2.0, scale=1.0, size=3000)
+    spline = RQSpline(n_knots=500).fit(x)
+    z, _ = spline.forward(x)
+    x_rec, _ = spline.inverse(z)
+    np.testing.assert_allclose(x_rec, x, atol=1e-4)
+
+
+def test_forward_approximately_gaussian(rng):
+    x = rng.exponential(scale=2.0, size=4000)
+    spline = RQSpline(n_knots=500).fit(x)
+    z, _ = spline.forward(x)
+    # The Gaussianized output should be close to standard normal.
+    assert abs(z.mean()) < 0.1
+    assert abs(z.std() - 1.0) < 0.15
+
+
+def test_monotonic_output(rng):
+    x = rng.standard_normal(1000)
+    spline = RQSpline(n_knots=200).fit(x)
+    grid = np.linspace(x.min(), x.max(), 500)
+    z, _ = spline.forward(grid)
+    # Strictly increasing forward map.
+    assert np.all(np.diff(z) > 0)
+
+
+def test_log_det_matches_numerical_gradient(rng):
+    x = rng.standard_normal(3000)
+    spline = RQSpline(n_knots=400).fit(x)
+    pts = np.linspace(-1.5, 1.5, 50)
+    _, log_dz_dx = spline.forward(pts)
+    h = 1e-6
+    z_plus, _ = spline.forward(pts + h)
+    z_minus, _ = spline.forward(pts - h)
+    numerical = (z_plus - z_minus) / (2 * h)
+    np.testing.assert_allclose(np.exp(log_dz_dx), numerical, rtol=1e-3, atol=1e-4)
+
+
+def test_inverse_log_det_is_negative_forward(rng):
+    x = rng.standard_normal(2000)
+    spline = RQSpline(n_knots=300).fit(x)
+    pts = np.linspace(-2.0, 2.0, 40)
+    z, log_dz_dx = spline.forward(pts)
+    _, log_dx_dz = spline.inverse(z)
+    np.testing.assert_allclose(log_dx_dz, -log_dz_dx, atol=1e-6)
+
+
+def test_tails_extrapolate_linearly(rng):
+    x = rng.standard_normal(2000)
+    spline = RQSpline(n_knots=200).fit(x)
+    # Points well outside the fitted support use linear tails -> finite,
+    # monotone, and exactly invertible.
+    far = np.array([x.min() - 5.0, x.max() + 5.0])
+    z, log_dz_dx = spline.forward(far)
+    assert np.all(np.isfinite(z))
+    assert np.all(np.isfinite(log_dz_dx))
+    x_rec, _ = spline.inverse(z)
+    np.testing.assert_allclose(x_rec, far, atol=1e-8)
+
+
+def test_constant_feature_is_identity():
+    x = np.full(100, 3.0)
+    spline = RQSpline().fit(x)
+    z, log_dz_dx = spline.forward(x)
+    np.testing.assert_allclose(z, 0.0, atol=1e-12)
+    np.testing.assert_allclose(log_dz_dx, 0.0)
+    x_rec, _ = spline.inverse(z)
+    np.testing.assert_allclose(x_rec, x)
+
+
+def test_n_knots_capped_to_samples(rng):
+    x = rng.standard_normal(10)
+    spline = RQSpline(n_knots=1000).fit(x)
+    assert spline.x_knots_.size <= 10

--- a/tests/test_stiefel.py
+++ b/tests/test_stiefel.py
@@ -1,0 +1,83 @@
+"""Tests for Stiefel-manifold projection-direction optimization."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from rbig._src.stiefel import (
+    max_sliced_wasserstein_directions,
+    random_orthogonal_directions,
+    wasserstein_1d,
+)
+
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng(0)
+
+
+def test_wasserstein_identical_is_zero(rng):
+    x = rng.standard_normal(500)
+    assert wasserstein_1d(x, x) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_wasserstein_shift(rng):
+    x = rng.standard_normal(5000)
+    assert wasserstein_1d(x, x + 3.0) == pytest.approx(3.0, abs=0.05)
+
+
+def test_wasserstein_unequal_sizes(rng):
+    x = rng.standard_normal(1000)
+    y = rng.standard_normal(700) + 2.0
+    assert wasserstein_1d(x, y) == pytest.approx(2.0, abs=0.1)
+
+
+@pytest.mark.parametrize("d,k", [(5, 1), (5, 2), (8, 8), (10, 5)])
+def test_random_directions_orthonormal(d, k):
+    A = random_orthogonal_directions(d, k, random_state=0)
+    assert A.shape == (d, k)
+    np.testing.assert_allclose(A.T @ A, np.eye(k), atol=1e-10)
+
+
+def test_random_directions_capped_to_d():
+    A = random_orthogonal_directions(4, 10, random_state=0)
+    assert A.shape == (4, 4)
+
+
+def _non_gaussian_data(rng, n=2000, d=4):
+    # First two coordinates are heavy-tailed / skewed; rest are Gaussian.
+    X = rng.standard_normal((n, d))
+    X[:, 0] = rng.exponential(1.0, n)
+    X[:, 1] = rng.standard_t(2.5, n)
+    return X
+
+
+@pytest.mark.parametrize("k", [1, 2, 4])
+def test_directions_orthonormal(rng, k):
+    X = _non_gaussian_data(rng)
+    Z = rng.standard_normal((2000, 4))
+    A = max_sliced_wasserstein_directions(X, Z, k, max_iter=30, random_state=0)
+    assert A.shape == (4, k)
+    np.testing.assert_allclose(A.T @ A, np.eye(k), atol=1e-8)
+
+
+def test_objective_improves(rng):
+    X = _non_gaussian_data(rng)
+    Z = rng.standard_normal((2000, 4))
+    _, history = max_sliced_wasserstein_directions(
+        X, Z, 2, max_iter=50, random_state=0, return_history=True
+    )
+    # The K-SWD maximization should never make the objective worse.
+    assert history[-1] >= history[0] - 1e-9
+    assert len(history) >= 1
+
+
+def test_finds_more_non_gaussian_direction_than_random(rng):
+    X = _non_gaussian_data(rng)
+    Z = rng.standard_normal((2000, 4))
+    A_opt = max_sliced_wasserstein_directions(X, Z, 1, max_iter=80, random_state=0)
+    A_rand = random_orthogonal_directions(4, 1, random_state=1)
+    swd_opt = wasserstein_1d(X @ A_opt[:, 0], Z @ A_opt[:, 0])
+    swd_rand = wasserstein_1d(X @ A_rand[:, 0], Z @ A_rand[:, 0])
+    assert swd_opt >= swd_rand

--- a/tests/test_stiefel.py
+++ b/tests/test_stiefel.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import itertools
+
 import numpy as np
 import pytest
 
@@ -62,22 +64,31 @@ def test_directions_orthonormal(rng, k):
     np.testing.assert_allclose(A.T @ A, np.eye(k), atol=1e-8)
 
 
-def test_objective_improves(rng):
+def test_objective_strictly_improves(rng):
     X = _non_gaussian_data(rng)
     Z = rng.standard_normal((2000, 4))
     _, history = max_sliced_wasserstein_directions(
-        X, Z, 2, max_iter=50, random_state=0, return_history=True
+        X, Z, 2, max_iter=80, random_state=0, return_history=True
     )
-    # The K-SWD maximization should never make the objective worse.
-    assert history[-1] >= history[0] - 1e-9
-    assert len(history) >= 1
+    # The optimizer must actually move: a no-op (returning the initial frame)
+    # would leave history at length 1 with no gain.
+    assert len(history) > 1
+    assert history[-1] > history[0] + 1e-3
+    # Monotone ascent: every accepted iterate improves the objective.
+    assert all(b >= a - 1e-9 for a, b in itertools.pairwise(history))
 
 
 def test_finds_more_non_gaussian_direction_than_random(rng):
     X = _non_gaussian_data(rng)
     Z = rng.standard_normal((2000, 4))
-    A_opt = max_sliced_wasserstein_directions(X, Z, 1, max_iter=80, random_state=0)
-    A_rand = random_orthogonal_directions(4, 1, random_state=1)
-    swd_opt = wasserstein_1d(X @ A_opt[:, 0], Z @ A_opt[:, 0])
-    swd_rand = wasserstein_1d(X @ A_rand[:, 0], Z @ A_rand[:, 0])
-    assert swd_opt >= swd_rand
+    # Averaged over several random initializations, the optimized direction
+    # is meaningfully more non-Gaussian than a random one.
+    swd_opt, swd_rand = [], []
+    for seed in range(5):
+        A_opt = max_sliced_wasserstein_directions(
+            X, Z, 1, max_iter=80, random_state=seed
+        )
+        A_rand = random_orthogonal_directions(4, 1, random_state=seed)
+        swd_opt.append(wasserstein_1d(X @ A_opt[:, 0], Z @ A_opt[:, 0]))
+        swd_rand.append(wasserstein_1d(X @ A_rand[:, 0], Z @ A_rand[:, 0]))
+    assert np.mean(swd_opt) > np.mean(swd_rand) + 0.05


### PR DESCRIPTION
## Summary

Implements the **code half** of the Sliced Iterative Gaussianization epic (#23) — the shared primitives, the layer, the two model classes, public exports, and the `SplineGaussianizer` refactor onto the shared spline.

Closes #68, #69, #70, #71, #72, #73, #74, #81.

## What's included

| Issue | Deliverable |
|---|---|
| #68 | `rbig/_src/spline.py` — `RQSpline`: strictly monotonic rational-quadratic spline, KDE→CDF knot placement, analytic forward/inverse + log-derivative, linear tails |
| #69 | `rbig/_src/stiefel.py` — `wasserstein_1d`, `random_orthogonal_directions`, `max_sliced_wasserstein_directions` (K-SWD via a Cayley curvilinear search) |
| #70 | `rbig/_src/convergence.py` — shared `StoppingCriterion` (log-likelihood / SWD / total-correlation early stopping) |
| #71 | `SIGLayer` — projection + per-direction spline Gaussianization with a tractable log-det |
| #72 / #73 | `GIS` and `SIG` sklearn estimators sharing one greedy flow engine |
| #74 | Public exports: `GIS`, `SIG`, `SIGLayer`, `RQSpline` |
| #81 | `SplineGaussianizer` now uses the shared `RQSpline` internally; public API and existing behavior preserved |

## Testing

- New: `tests/test_spline.py`, `tests/test_stiefel.py`, `tests/test_convergence.py`, `tests/test_sliced.py` (52 tests).
- Full suite **403 passed / 1 skipped**; `ruff check .` and `ruff format --check .` both clean.
- GIS/SIG `inverse(transform(x))` roundtrip error ≈ 1e-15 (analytic spline inverse).

## Two judgment calls worth a look

1. **#70 — `AnnealedRBIG` not rewired.** The `StoppingCriterion` module supports the `total_correlation` metric so it *can* drop into `AnnealedRBIG`, but I did not rewire `AnnealedRBIG`'s inline stopping to avoid risking its existing, well-tested convergence behavior. `GIS`/`SIG` use the new module.
2. **GIS vs SIG is configuration-level.** Both are implemented as one greedy data→Gaussian flow (a symmetric bijection): `GIS` is oriented toward density estimation (`transform`/`score_samples`, `log_likelihood` stopping) and `SIG` toward generation (`sample`/`inverse_transform`, `swd` stopping). This is a simplification of the issue's literal "build layers in reverse / prepend" description, but functionally correct and sklearn-clean.

## Not included (deferred docs half of #23)

#75 (theory page) and #76–#80 (five executed notebooks) are intentionally out of scope for this PR.

https://claude.ai/code/session_01JWacugtFBatLeiZ1UW274X

---
_Generated by [Claude Code](https://claude.ai/code/session_01JWacugtFBatLeiZ1UW274X)_